### PR TITLE
Create harbour-scoreboard-sv.ts

### DIFF
--- a/translations/harbour-scoreboard-sv.ts
+++ b/translations/harbour-scoreboard-sv.ts
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>About</name>
+    <message>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <source>A simple scoreboard app for Sailfish OS. Made by jollailija. Icon by Moth.</source>
+        <translation>En enkel resultattavel-app för SailfishOS. Skapad av jollailija. Ikon av Moth.</translation>
+    </message>
+</context>
+<context>
+    <name>Help</name>
+    <message>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <source>How to use</source>
+        <translation>Så gör man</translation>
+    </message>
+    <message>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>General
+* Tap the “+” and “-“ buttons to change team scores. You can also add points using the cover actions. To change numbers of won rounds, tap first the small round numbers followed by tapping the +/- buttons. Get back to changing team scores by tapping the score numbers. Values are always automatically saved when modified.
+
+PullDownMenu
+* To reset the scores or the won rounds, use the &apos;Reset scores/rounds&apos;-action in the PullDownMenu. This will reset the highlighted value. You have three seconds to cancel it by tapping the remorse notification.
+* Use &apos;Saved scores&apos; in the PullDownMenu to fetch previous scores and rounds from the database. Beware that the saved values will be overwritten after any following changes.
+* To set new values directly, use the &apos;Set scores &amp; rounds’ menu item and fill them in the corresponding text fields.</source>
+        <translation>Allmänt
+* Tryck på plus- och minusknapparna (+/-) för att ändra lagens poäng. Du kan också lägga till poäng via programminiatyren. För att ändra antalet vunna rundor, trycker du först de små runda siffrorna följt av +/-. Återgå till lagpoängen genom att trycka på poängsiffran. Värdena sparas alltid automatiskt vid varje ändring.
+
+Rullgardinsmeny
+* För att återställa poäng eller vunna rundor, använder du &apos;Återställ poängställning/rundor&apos; i rullgardinsmenyn. Detta kommer att nollställa det markerade värdet. Du har tre sekunder på dig att ångra återställningen genom att trycka på återställningsmeddelandet.
+* Använd &apos;Sparade poängställningar&apos; för att hämta tidigare poängställningar och rundor från databasen. Notera att sparade värden kommer att skrivas över om du ändrar något.
+* För att ange nya värden direkt, använder du &apos;Ange poäng &amp; rundor&apos; i menyn, där du fyller i respektive textfält.</translation>
+    </message>
+</context>
+<context>
+    <name>harbour-scoreboard</name>
+    <message>
+        <source>Scoreboard</source>
+        <translation>Resultattavla</translation>
+    </message>
+    <message>
+        <source>Resetting scores</source>
+        <translation>Återställer poängställning</translation>
+    </message>
+    <message>
+        <source>Reset scores</source>
+        <translation>Återställ poängställning</translation>
+    </message>
+    <message>
+        <source>Set scores</source>
+        <translation>Ange poängställning</translation>
+    </message>
+    <message>
+        <source>Set home score</source>
+        <translation>Ange hemmapoäng</translation>
+    </message>
+    <message>
+        <source>Set visitor score</source>
+        <translation>Ange bortapoäng</translation>
+    </message>
+    <message>
+        <source>Home score</source>
+        <translation>Hemmaställning</translation>
+    </message>
+    <message>
+        <source>Visitor score</source>
+        <translation>Bortaställning</translation>
+    </message>
+    <message>
+        <source>Set scores &amp; rounds</source>
+        <translation>Ange poäng &amp; rundor</translation>
+    </message>
+    <message>
+        <source>Press enter to save</source>
+        <translation>Tryck Retur för att spara</translation>
+    </message>
+    <message>
+        <source>Resetting rounds</source>
+        <translation>Återställer rundor</translation>
+    </message>
+    <message>
+        <source>Reset rounds</source>
+        <translation>Återställ rundor</translation>
+    </message>
+    <message>
+        <source>Help</source>
+        <translation>Hjälp</translation>
+    </message>
+    <message>
+        <source>Home score set.</source>
+        <translation>Hemmaställning klar.</translation>
+    </message>
+    <message>
+        <source>Visitor score set.</source>
+        <translation>Bortaställning klar.</translation>
+    </message>
+    <message>
+        <source>Home rounds set.</source>
+        <translation>Hemmarundor klart.</translation>
+    </message>
+    <message>
+        <source>Visitor rounds set.</source>
+        <translation>Bortarundor klart.</translation>
+    </message>
+    <message>
+        <source>Home rounds</source>
+        <translation>Hemmarundor</translation>
+    </message>
+    <message>
+        <source>Set home rounds</source>
+        <translation>Ange hemmarundor</translation>
+    </message>
+    <message>
+        <source>Visitor rounds</source>
+        <translation>Bortarundor</translation>
+    </message>
+    <message>
+        <source>Set visitor rounds</source>
+        <translation>Ange bortarundor</translation>
+    </message>
+    <message>
+        <source>Saved scores</source>
+        <translation>Sparade poängställningar</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Swedish translation if wanted. Don't know why, but help text doesn't translate. Only topic translated on help page in my tests.
